### PR TITLE
Fix: Re-assign firstDay value when 1st day of the week occurs on Sunday

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -58,7 +58,13 @@ export interface ICalendar {
 }
 
 export const getCalendar = (month: number, year: number, startingDay: number = 1): ICalendar => {
-  const firstDay = new Date(year, month).getDay();
+  let firstDay = new Date(year, month).getDay();
+
+  // NOTE : getDay() will return 0 when 1st day of the week occurs on Sunday
+  if (firstDay === 0) {
+    firstDay = 7;
+  }
+
   const daysInCalendar = daysInMonth(month, year);
   const calendar: TDate[][] = [];
 


### PR DESCRIPTION
Issue:
getDay() will return 0 when 1st day of the week occurs on Sunday.
This particular scenario will offset the day number for its respective day name.
E.g. : 1st January 2023 will be Monday while the actual should be on Sunday.
