### PR TITLE
Fix: Days of Final Week not Continuing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ response:
 
 ### Methods
 
-**getCalendar(month: number, year: number, startingDay?: number): [ICalendar](#types)**
+**getCalendar(month: number, year: number, options?: [IOptions](#types)): [ICalendar](#types)**
 
 Parameters
 
@@ -58,7 +58,8 @@ Parameters
 | ----------- | ------ | -------- | ------- | -------------------------------------------------------------- |
 | month       | Number | Yes      | -       | The month of the calendar (0 to 11). 0 = January, 1 = February |
 | year        | Number | Yes      | -       | The year of the calendar                                       |
-| startingDay | Number | No       | 1       | The starting day of the week (0 to 6). 0 = Sunday, 1 = Monday  |
+| options.startingDay | [TStartingDay](#types) | No       | 1       | The starting day of the week (0 to 6). 0 = Sunday, 1 = Monday  |
+| options.extraWeek | Boolean | No       | true       | Calendar rows are fixed to 6 regardless of all the 6th week consists of days for next month  |
 
 ---
 
@@ -97,6 +98,13 @@ interface ICalendar {
     month: number,
     year: number,
   };
+}
+
+export type TStartingDay = 0 | 'SUNDAY' | 'Sunday' | 'sunday' | 1 | 'MONDAY' | 'Monday' | 'monday' | 2 | 'TUESDAY' | 'Tuesday' | 'tuesday' | 3 | 'WEDNESDAY' | 'Wednesday' | 'wednesday' | 4 | 'THURSDAY' | 'Thursday' | 'thursday' | 5 | 'FRIDAY' | 'Friday' | 'friday' | 6 | 'SATURDAY' | 'Saturday' | 'saturday';
+
+export interface IOptions {
+  startingDay?: TStartingDay | number;
+  extraWeek?: boolean;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skolacode/calendar-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple JavaScript calendar generator",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__test__/calendar.test.ts
+++ b/src/__test__/calendar.test.ts
@@ -17,3 +17,12 @@ test('test getCalendar function', () => {
   expect(july2022Calendar.calendar[5][6].isCurrentMonth).toEqual(false)
   expect(july2022Calendar.calendar[5][6].weekday).toEqual('Sunday')
 })
+
+// failed story : https://github.com/skolacode/calendar-js/issues/2
+// sample data : November 2022 - Week 5 ended on the 4th, and Week 6 began on the 1st, not the 5th.
+test('test first day of 6th week should be December 5, Monday', () => {
+  const dateCal = getCalendar(10, 2022);
+  const totalWeek = dateCal.calendar.length;
+  expect(dateCal.calendar[totalWeek - 1][0].day).toEqual(5);
+  expect(dateCal.calendar[totalWeek - 1][0].weekday).toEqual('Monday')
+})


### PR DESCRIPTION
1. Fix [failed case](https://github.com/skolacode/calendar-js/issues/2)
Sample data: November 2022
- Week 5 ended on the 4th, and Week 6 began on the 1st, not the 5th
- The correct one, Week 6 should begin on 5th

2. Add ```options``` object as 3rd parameter
- Also handles old version method invoked using ```startingDay``` as 3rd parameter
